### PR TITLE
Update HElib repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Libraries
 
-- [HElib](https://github.com/shaih/HElib) - Brakerski-Gentry-Vaikuntanathan (BGV) scheme.
+- [HElib](https://github.com/HomEnc/HElib) - Brakerski-Gentry-Vaikuntanathan (BGV) scheme.
 - [SEAL](http://sealcrypto.org) - "FullRNS" optimization of Fan-Vercauteren (FV) scheme.
 - [FHEW](https://github.com/lducas/FHEW) - Fully HE library.
 - [HEAAN](https://github.com/kimandrik/HEAAN) -  Scheme with native support for fixed point approximate arithmetic.


### PR DESCRIPTION
From [shaih/HElib](https://github.com/shaih/HElib):

April 2019: Moved the HElib reposiroty on github from shaih/HElib to HomEnc/HElib



**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/jonaschn/awesome-he/blob/master/CONTRIBUTING.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
