### PR TITLE
Add TenSEAL to Libaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [SEAL-python](https://github.com/Huelse/SEAL-Python/) - Python binding for the [Microsoft SEAL](#SEAL) library.
 - [SparkFHE](https://github.com/SpiRITlab/spark) - Apache Spark with an add-on for FHE computations. See [:page_facing_up:](https://homomorphicencryption.org/wp-content/uploads/2019/08/poster_5.pdf).
 - <a name="tfhe">[tfhe](https://github.com/tfhe/tfhe) - Faster fully HE: Bootstrapping in less than 0.1 seconds.</a>
-- [TenSEAL](https://github.com/OpenMined/TenSEAL) - Library for HE operations on tensors, built on Microsoft SEAL, with a Python API.
+- [TenSEAL](https://github.com/OpenMined/TenSEAL) - Library for HE operations on tensors, built on [Microsoft SEAL](#SEAL)
+, with a Python API.
 
 
 ## Toolkits

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [SEAL-python](https://github.com/Huelse/SEAL-Python/) - Python binding for the [Microsoft SEAL](#SEAL) library.
 - [SparkFHE](https://github.com/SpiRITlab/spark) - Apache Spark with an add-on for FHE computations. See [:page_facing_up:](https://homomorphicencryption.org/wp-content/uploads/2019/08/poster_5.pdf).
 - <a name="tfhe">[tfhe](https://github.com/tfhe/tfhe) - Faster fully HE: Bootstrapping in less than 0.1 seconds.</a>
-- [TenSEAL](https://github.com/OpenMined/TenSEAL) - Library for HE operations on tensors, built on [Microsoft SEAL](#SEAL)
-, with a Python API.
+- [TenSEAL](https://github.com/OpenMined/TenSEAL) - Library for HE operations on tensors, built on [Microsoft SEAL](#SEAL), with a Python API.
 
 
 ## Toolkits

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [SEAL-python](https://github.com/Huelse/SEAL-Python/) - Python binding for the [Microsoft SEAL](#SEAL) library.
 - [SparkFHE](https://github.com/SpiRITlab/spark) - Apache Spark with an add-on for FHE computations. See [:page_facing_up:](https://homomorphicencryption.org/wp-content/uploads/2019/08/poster_5.pdf).
 - <a name="tfhe">[tfhe](https://github.com/tfhe/tfhe) - Faster fully HE: Bootstrapping in less than 0.1 seconds.</a>
+- [TenSEAL](https://github.com/OpenMined/TenSEAL) - Library for HE operations on tensors, built on Microsoft SEAL, with a Python API.
 
 
 ## Toolkits


### PR DESCRIPTION
"[TenSEAL](https://github.com/OpenMined/TenSEAL) is a library for doing homomorphic encryption operations on tensors, built on top of [Microsoft SEAL](https://github.com/Microsoft/SEAL). It provides ease of use through a Python API, while preserving efficiency by implementing most of its operations using C++."