### PR TITLE
Add Blyss to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## Libraries
 
 Libraries that can be used to implement applications using (Fully) Homomorphic Encryption.
+- [blyss](https://github.com/blyssprivacy/sdk) - Rust FHE library specialized for private information retrieval. Includes bindings to JS & Python.
 - [concrete](https://github.com/zama-ai/concrete) - Rust FHE library that implements Zama's variant of TFHE.
 - [cuFHE](https://github.com/vernamlab/cuFHE) - CUDA-accelerated Fully Homomorphic Encryption Library.
 - [cuHE](https://github.com/vernamlab/cuHE) - GPU-accelerated HE library for NVIDIA CUDA-Enabled GPUs.


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/jonaschn/awesome-he/blob/master/CONTRIBUTING.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

Proposal to add Blyss, which is an FHE library focused on private information retrieval. Currently, the library offers fast, optimized implementations of the [Spiral](https://eprint.iacr.org/2022/368) and [SimplePIR](https://eprint.iacr.org/2022/949) schemes, both implemented in Rust. Code is MIT-licensed.

This library is developed by Blyss Inc., a company committed to open-source cryptography. 