### PR TITLE
Move Concrete from libraries section to toolkits

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [Sunscreen](https://github.com/Sunscreen-tech/Sunscreen) - Rust compiler for the BFV fully homomorphic encryption scheme.
 - [TenSEAL](https://github.com/OpenMined/TenSEAL) - Library for HE operations on tensors, built on [Microsoft SEAL](#SEAL), with a Python API.
 - <a name="tfhe">[tfhe](https://github.com/tfhe/tfhe) - Faster fully HE: Bootstrapping in less than 0.1 seconds.</a>
-- [TFHE-rs](https://github.com/zama-ai/tfhe-rs) - Rust implementation of TFHE for booleans and small integer arithmetics over encrypted data by [Zama](https://github.com/zama-ai).
+- [TFHE-rs](https://github.com/zama-ai/tfhe-rs) - Rust implementation of the TFHE scheme for boolean and integers FHE arithmetics by [Zama](https://github.com/zama-ai).
 
 
 ## Toolkits

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 
 Libraries that can be used to implement applications using (Fully) Homomorphic Encryption.
 - [blyss](https://github.com/blyssprivacy/sdk) - Rust FHE library specialized for private information retrieval. Includes bindings to JS & Python.
-- [concrete](https://github.com/zama-ai/concrete) - Rust FHE library that implements Zama's variant of TFHE.
 - [cuFHE](https://github.com/vernamlab/cuFHE) - CUDA-accelerated Fully Homomorphic Encryption Library.
 - [cuHE](https://github.com/vernamlab/cuHE) - GPU-accelerated HE library for NVIDIA CUDA-Enabled GPUs.
 - [Cupcake](https://github.com/facebookresearch/Cupcake) - Facebook's Rust library for the (additive version of the) Fan-Vercauteren scheme.
@@ -56,6 +55,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [ALCHEMY](https://github.com/cpeikert/ALCHEMY) - Haskell-based DSLs and interpreters/compilers, build on top of the lattice crypto library Lol.
 - [AWS HE toolkit](https://github.com/awslabs/homomorphic-implementors-toolkit) - Simplifies the process of designing circuits for the CKKS scheme.
 - [Cingulata](https://github.com/CEA-LIST/Cingulata) - Compiler toolchain and RTE for running C++ programs over encrypted data.
+- [Concrete](https://github.com/zama-ai/concrete) - TFHE compiler for converting Python programs into FHE equivalents.
 - [Concrete-ML](https://github.com/zama-ai/concrete-ml) - Python-based toolkit for data scientists w/o prior FHE knowledge (using sklearn, pyTorch, XGBoost models). 
 - [E3](https://github.com/momalab/e3) - Encrypt-Everything-Everywhere framework for compiling C++ programs with encrypted operands.
 - [EVA](https://github.com/microsoft/EVA) - A compiler and optimizer for the CKKS scheme (targeting [Microsoft SEAL](#SEAL)).


### PR DESCRIPTION
*By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/jonaschn/awesome-he/blob/master/CONTRIBUTING.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖*

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

As of April 13, the Concrete repository does not no longer offer a HE library for Rust but only represents a TFHE compiler (see [announcement](https://www.zama.ai/post/announcing-concrete-v1-0-0)).
Therefore, I moved the Concrete listing from the libraries section to toolkits.