### PR TITLE
Remove redundant licence info as GitHub natively displays it now

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,3 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 🚀 Contribute further [awesome HE](https://github.com/jonaschn/awesome-he/edit/master/README.md) projects
 
 💸 Spare me some ~~coffee~~ tea 🍵 via [Paypal](https://www.paypal.me/JonathanSchneiderDE/3)
-
-## License
-
-[![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](http://creativecommons.org/publicdomain/zero/1.0)
-
-To the extent possible under law, Jonathan Schneider has waived all copyright and
-related or neighboring rights to this work.


### PR DESCRIPTION
**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/jonaschn/awesome-he/blob/master/CONTRIBUTING.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
