### PR TITLE
Add Fheanor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [TenSEAL](https://github.com/OpenMined/TenSEAL) - Library for HE operations on tensors, built on [Microsoft SEAL](#SEAL), with a Python API.
 - <a name="tfhe">[tfhe](https://github.com/tfhe/tfhe) - Faster fully HE: Bootstrapping in less than 0.1 seconds.</a>
 - [TFHE-rs](https://github.com/zama-ai/tfhe-rs) - Rust implementation of the TFHE scheme for boolean and integers FHE arithmetics by [Zama](https://github.com/zama-ai).
+- [Fheanor](https://github.com/FeanorTheElf/Fheanor) - Rust implementation of BGV, BFV and CLPX/GBFV, with explicit support for designing new schemes and modifying existing ones. 
 
 ## Toolkits
 


### PR DESCRIPTION
It would be great if [Fheanor](https://github.com/FeanorTheElf/fheanor) could be added to the list. It's an FHE library written in Rust, with the goal of making research on variants of FHE schemes easier.

How this meets the guidelines for contribution:
 - We uploaded an accompanying paper to eprint [https://ia.cr/2025/864](https://ia.cr/2025/864) a few days ago, but the library has been in development for more than a year (previously being called HE-Ring).
 - In terms of implemented features, the project has some similarity with HElib and other BGV/BFV libraries, but has different design goals.
 - Adding `Fheanor` has not been proposed previously.
 - `Fheanor` has an extensive documentation, available on [https://docs.rs/fheanor/latest/fheanor/](https://docs.rs/fheanor/latest/fheanor/)