### PR TITLE
Add fhe poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [Rosetta](https://github.com/LatticeX-Foundation/Rosetta) - A privacy-preserving framework based on TensorFlow.
 - [tf-encrypted](https://github.com/tf-encrypted/tf-encrypted) - Bridge between TensorFlow and the [Microsoft SEAL](#SEAL) library.
 - [Zama's Hugging Face spaces](https://huggingface.co/zama-fhe) - Demo apps showing the power of FHE for real-world use cases.
-- [Private polls (demo)](https://www.cryptool.org/en/cto/he-poll/) - Browser-based demo app using [node-seal](#node-seal) to conduct a poll with HE
+- [Private polls (demo)](https://www.cryptool.org/en/cto/he-poll/) - Browser-based demo app using [node-seal](#node-seal) to conduct a poll with HE.
 
 ## Databases
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [LightPHE](https://github.com/serengil/LightPHE) - A Python wrapping Partially HE library (RSA, ElGamal, Paillier, Damgard-Jurik, Benaloh, and more).
 - <a name="SEAL">[Microsoft SEAL](https://github.com/microsoft/SEAL) - C++ FHE library implementing BFV and CKKS schemes.</a>
 - [NFLlib](https://github.com/quarkslab/NFLlib) - NTT-based Fast Lattice library specialized on power-of-two polynomials.
-- [node-seal](https://github.com/morfix-io/node-seal) - JavaScript/WebAssembly port of [Microsoft SEAL](#SEAL).
+- <a name="node-seal">[node-seal](https://github.com/morfix-io/node-seal) - JavaScript/WebAssembly port of [Microsoft SEAL](#SEAL).
 - [NuFHE](https://github.com/nucypher/nufhe) - GPU-accelerated HE library, faster than cuFHE, that implements the [tfhe](#tfhe) algorithms.
 - <a name="OpenFHE">[OpenFHE](https://github.com/openfheorg/openfhe-development) - C++ FHE library implementing all major schemes along with bootstrapping and scheme switching.
 - <a name="OpenFHE-Python">[OpenFHE-Python](https://github.com/openfheorg/openfhe-python) - Python wrapper for [OpenFHE](#OpenFHE).

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [AWS HE toolkit](https://github.com/awslabs/homomorphic-implementors-toolkit) - Simplifies the process of designing circuits for the CKKS scheme.
 - [Cingulata](https://github.com/CEA-LIST/Cingulata) - Compiler toolchain and RTE for running C++ programs over encrypted data.
 - [Concrete](https://github.com/zama-ai/concrete) - TFHE compiler for converting Python programs into FHE equivalents.
-- [Concrete-ML](https://github.com/zama-ai/concrete-ml) - Python-based toolkit for data scientists w/o prior FHE knowledge (using sklearn, pyTorch, XGBoost models). 
+- [Concrete-ML](https://github.com/zama-ai/concrete-ml) - Python-based toolkit for data scientists w/o prior FHE knowledge (using sklearn, pyTorch, XGBoost models).
 - [E3](https://github.com/momalab/e3) - Encrypt-Everything-Everywhere framework for compiling C++ programs with encrypted operands.
 - [EVA](https://github.com/microsoft/EVA) - A compiler and optimizer for the CKKS scheme (targeting [Microsoft SEAL](#SEAL)).
 - [Google's FHE Repository](https://github.com/google/fully-homomorphic-encryption) - A compiler that converts a subset of C++ programs into FHE circuits implemented in various backend libraries (superseded by [HEIR](#HEIR)).
@@ -87,6 +87,7 @@ Libraries that can be used to implement applications using (Fully) Homomorphic E
 - [Rosetta](https://github.com/LatticeX-Foundation/Rosetta) - A privacy-preserving framework based on TensorFlow.
 - [tf-encrypted](https://github.com/tf-encrypted/tf-encrypted) - Bridge between TensorFlow and the [Microsoft SEAL](#SEAL) library.
 - [Zama's Hugging Face spaces](https://huggingface.co/zama-fhe) - Demo apps showing the power of FHE for real-world use cases.
+- [Private polls (demo)](https://www.cryptool.org/en/cto/he-poll/) - Browser-based demo app using [node-seal](#node-seal) to conduct a poll with HE
 
 ## Databases
 


### PR DESCRIPTION
Adding a link to a web-app demonstrating the conduction of a poll that uses HE.
In contrast to the already existent link to lattigo-polls, this demo is already live and ready-to-use on cryptool.org. It also uses a different FHE library. I wouldn't replace it but see it as an addition.

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/jonaschn/awesome-he/blob/master/CONTRIBUTING.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
